### PR TITLE
Made compatible with Python 3.

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -39,7 +39,7 @@ class Glyph():
             self.end = None
 
         if self.start == None or self.end == None:
-            print("Problem with instruction set", file=sys.stderr)
+            print("Problem with instructions in glyph:", file=sys.stderr)
             for i in instructions:
                 print("%s (%s)" % (i.line, i.typename), file=sys.stderr)
 
@@ -171,18 +171,18 @@ def reorder_greedy(gs, index=0):
 
     This is O(n^2). Pretty sure it can't be optimized into a sort.
     """
+    from operator import itemgetter
     gs = list(gs)
     ordered = [gs.pop(index)]
     prev = ordered[0]
     while len(gs) > 0:
-        from operator import methodcaller
         def dist_with_reverse_flag(g):
-            return min([
-                (prev.distance_to(g), 0, False, g),
-                (prev.distance_to_if_other_reversed(g), 1, True, g)
-            ])
+            return min([(prev.distance_to(g), 0, False, g),
+                        (prev.distance_to_if_other_reversed(g), 1, True, g)],
+                       key=itemgetter(0))
 
-        (dist, tiebreaker, reverse, nearest) = min(map(dist_with_reverse_flag, gs))
+        (dist, tiebreaker, reverse, nearest) = min(map(dist_with_reverse_flag, gs),
+                                                   key=itemgetter(0))
         gs.remove(nearest)
 
         if reverse:

--- a/process.py
+++ b/process.py
@@ -34,14 +34,14 @@ print("Deduped total distance: %9d" % total_travel(glyphs), file=sys.stderr)
 # easy sort: sort all glyphs by starting point
 #
 # This is O(n log n) because it's simply a sort.
-from operator import attrgetter
-sorted_g = sorted(glyphs, key=attrgetter('start'))
+sorted_g = sorted(glyphs,
+                  key=lambda st: st.start or tuple())  # add default key in case 'start' is missing.
 print("Sorted penup distance:  %9d" % total_penup_travel(sorted_g), file=sys.stderr)
 print("Sorted total distance:  %9d" % total_travel(sorted_g), file=sys.stderr)
 
 # Try a few starting points with the greedy sort, just to make sure we don't
 # happen to start somewhere crazy.
-for i in range(0, len(glyphs), len(glyphs) / 15):
+for i in range(0, len(glyphs), int(len(glyphs) / 15)):
     greedy = reorder_greedy(glyphs, index=i)
     print("Greedy penup (i=%d)      %9d" % (i, total_penup_travel(greedy)), file=sys.stderr)
     print("Greedy total (i=%d)      %9d" % (i, total_travel(greedy)), file=sys.stderr)


### PR DESCRIPTION
Added a default value to the sorted() call in process.py:38. Necessary because a glyph with no 'pen down' ends up with a start of None, and comparing None to a tuple during the sorted now causes a problem in python3.
Tested with python3.4 and 2.7, resulting in the same output file with both.
